### PR TITLE
vomnibar: quickly access items with 'alt + num'

### DIFF
--- a/front/vomnibar.html
+++ b/front/vomnibar.html
@@ -59,8 +59,9 @@ match{color:#000;font-weight:bold;}.title>match{text-decoration:underline;}
 </div>
 <div id="list">
 	<script type="text/x-template" id="template">
-	<div class="item">
+	<div class="item" accesskey="{{num}}">
 		<div class="top">
+			<span>{{num}}.</span>
 			<svg class="icon{{level}}{{favIcon}}" viewBox="0 0 64 64">
 				<path class="{{typeIcon}}" />
 			</svg><span class="title">{{title}}</span>{{label}}

--- a/front/vomnibar.ts
+++ b/front/vomnibar.ts
@@ -1275,15 +1275,16 @@ VUtils_ = {
     const parser = Build.BTypes & ~BrowserType.Firefox ? 0 as never : new DOMParser();
     return function (objectArray, element): void {
       let html = "", len = a.length - 1;
-      for (const o of objectArray) {
+      objectArray.forEach((o, idx) => {
         let j = 0;
         for (; j < len; j += 2) {
           html += a[j];
           const key = a[j + 1];
           html += key === "typeIcon" ? Vomnibar_.getTypeIcon_(o) : o[key as keyof SuggestionE] || "";
+          html += key === "num" ? (idx + 1) : "";
         }
         html += a[len];
-      }
+      });
       if (Build.BTypes & ~BrowserType.Firefox) {
         element.innerHTML = html;
       } else {


### PR DESCRIPTION
Quick access by adding `accesskey` attribute to each item。
Shortcuts for various browsers on various platforms：

Browser | Windows | Linux | Mac
-- | -- | -- | --
Internet Explorer | [Alt] + accesskey | N/A |  
Chrome | [Alt] + accesskey | [Alt] + accesskey | [Control] [Alt] + accesskey
Firefox | [Alt] [Shift] + accesskey | [Alt] [Shift] + accesskey | [Control] [Alt] + accesskey
Safari | [Alt] + accesskey | N/A | [Control] [Alt] + accesskey
Opera | Opera 15 or newer: [Alt] + accesskeyOpera 12.1 or older: [Shift] [Esc] + accesskey

