### PR TITLE
Add new option to customize blank new tab HTML/CSS

### DIFF
--- a/background/settings.ts
+++ b/background/settings.ts
@@ -365,6 +365,7 @@ saladict@crimx.com`
     localeEncoding: "gbk",
     mouseReachable: true,
     /** mutable */ newTabUrl: "",
+    userDefinedNewTab: "",
     nextPatterns: "\u4e0b\u4e00\u5c01,\u4e0b\u9875,\u4e0b\u4e00\u9875,\u4e0b\u4e00\u7ae0,\u540e\u4e00\u9875\
 ,\u4e0b\u4e00\u5f20,next,more,newer,>,\u203a,\u2192,\xbb,\u226b,>>",
     notifyUpdate: true,

--- a/pages/blank.html
+++ b/pages/blank.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <head>
-<meta charset="utf-8">
-<title>Blank Page</title>
-<meta name="color-scheme" content="light dark">
-<script src="loader.js"></script>
+    <meta charset="utf-8">
+    <title>Blank Page</title>
+    <meta name="color-scheme" content="light dark">
+    <script src="loader.js"></script>
+</head>
+<body id="vimium-user-content"></body>

--- a/pages/loader.ts
+++ b/pages/loader.ts
@@ -84,6 +84,12 @@ var VApi: VApiTy | undefined, VimiumInjector: VimiumInjectorTy | undefined | nul
       }
       return browser_.runtime.lastError
     })
+    storage.get("userDefinedNewTab", (res): void => {
+      if (!res.userDefinedNewTab) { return }
+      const userContentBody = document.getElementById('vimium-user-content');
+      if (!userContentBody) { return }
+      userContentBody.insertAdjacentHTML('beforeend', res.userDefinedNewTab);
+    });
     if (browser_.i18n.getMessage("lang1")) {
       const s = browser_.i18n.getMessage("vblank")
       s && (document.title = s)

--- a/pages/options.html
+++ b/pages/options.html
@@ -521,6 +521,17 @@ key: https://c.com/$s/space=\s\ space_end
           </div></td>
         </tr>
         <tr>
+          <td class="caption">Custom HTML/CSS for blank page</td>
+          <td>
+            <textarea id="userDefinedNewTab" class="code min-height-4" inputmode="text" data-model="Text" lang="en"
+              placeholder="&lt;center&gt;&lt;h2&gt;Welcome to your new page&lt;h2&gt;&lt;center&gt;"
+              ></textarea>
+          </td>
+          <td class="help"><div class="help-inner">
+            If the "New tab URL" is configured on "pages/blank.html", it can be customized with static content.
+          </div></td>
+        </tr>
+        <tr>
           <td class="caption" data-i="68">Previous patterns</td>
           <td>
             <input id="previousPatterns" type="text" data-model="NonEmptyText" autocomplete="off" />

--- a/typings/vimium_c.d.ts
+++ b/typings/vimium_c.d.ts
@@ -343,6 +343,7 @@ declare namespace SettingsNS {
     grabBackFocus: boolean;
     showAdvancedCommands: boolean;
     vomnibarOptions: SelectNVType<VomnibarOptionItems> & VomnibarBackendItems;
+    userDefinedNewTab: string;
   }
   interface FrontUpdateAllowedSettings {
     showAdvancedCommands: 0;


### PR DESCRIPTION
Hi there!

This is a proposal to fix #980, allowing Vimium users to customize the look of `pages/blank.html` for new tabs.

It adds a new option to the settings: 
![2024-01-03T10:03:21,028486322+01:00](https://github.com/gdh1995/vimium-c/assets/4193924/7d7c1ed0-5dba-422b-be84-025ccb62dfb5)

This makes it possible to create elegant new tab pages ([source](https://github.com/Nainish-Rai/aesthetic-startpage)): 
![2024-01-03T10:05:10,638301729+01:00](https://github.com/gdh1995/vimium-c/assets/4193924/f0afa453-2b39-4ac9-9b8b-f86d48e8b0c7)

The great thing is that is supports Vimium keybinds as well: 
![2024-01-03T10:07:47,661332728+01:00](https://github.com/gdh1995/vimium-c/assets/4193924/89f32e3c-74da-4b2e-a4d0-14e94799a8de)

I attached the "custom HTML/CSS" I used if one wants to try it out: [startpage.txt](https://github.com/gdh1995/vimium-c/files/13817475/startpage.txt)

---

The main advantage of this solution compared to using another extension is that it maintains the browser's focus on page content. This avoids the need for cumbersome workarounds such as closing and reopening the new tab to remove focus from the address bar, which creates visual disturbances.

I believe the changes are minimal yet can significantly enhances the user experience. What do you think?