### PR TITLE
fix: '<number>0' in vim motions edge case

### DIFF
--- a/content/key_handler.ts
+++ b/content/key_handler.ts
@@ -151,7 +151,14 @@ export const checkKey = ((event: HandlerNS.Event, key: string
         result = HandlerResult.Nothing
       }
     } else {
-      nextKeys = keyFSM
+      const numPrefix = parseInt(key, 10);
+      if (!isNaN(numPrefix) && numPrefix >= 0 && numPrefix <= 9) {
+        nextKeys = keyFSM;
+        const digitPattern = new RegExp('^\\d+');
+        currentKeys = (currentKeys.match(digitPattern) || [''])[0] + numPrefix;
+      } else {
+        nextKeys = keyFSM;
+      }
     }
   }
   return result


### PR DESCRIPTION
When you do a motion in visual mode like '10w', when you hit '0', the code would consider it as a separate command to go back to the beginning of the line. With this fix, we emulate what vim does by allowing the user to keep appending numbers after the first nonzero digit in the motion. Built and tested locally as well!